### PR TITLE
feat/clear other locks

### DIFF
--- a/snowlock/lock.py
+++ b/snowlock/lock.py
@@ -107,13 +107,14 @@ def lock(
             logger.info("Created lock table %s and retrying", table)
         finally:
             if lock_acquired:
-                logger.info("Releasing locks for %s", session_id)
+                logger.info("Releasing locks on %s for %s", resource, client)
                 execute_query(
                     conn=conn,
                     sql=f"""
                     update {table}
                     set acquired=false
-                    where session_id='{session_id}'
+                    where client='{client}'
+                    and resource='{resource}'
                     """,
                 )
                 retry_attempt = MAX_RETRIES

--- a/snowlock/lock.py
+++ b/snowlock/lock.py
@@ -1,5 +1,5 @@
 import contextlib
-from uuid import uuid4, UUID
+from uuid import uuid4
 from typing import Iterator
 from logging import getLogger
 from snowflake.connector import SnowflakeConnection
@@ -13,8 +13,12 @@ logger = getLogger(__name__)
 
 @contextlib.contextmanager
 def lock(
-    client: str, resource: str, conn: SnowflakeConnection, table: str = "lock"
-) -> Iterator[UUID]:
+    client: str,
+    resource: str,
+    conn: SnowflakeConnection,
+    table: str = "lock",
+    session_lock: bool = False,
+) -> Iterator[str]:
     """Creates a lock using a Snowflake table.
 
     Args:
@@ -22,11 +26,12 @@ def lock(
         resource (str): The resource to lock.
         conn (SnowflakeConnection): The Snowflake connection to use.
         table (str, optional): The table to use for locking, it will be created if it does not exist. Defaults to "lock".
+        session_lock (bool, optional): Whether to prevent different sessions of the same client acquiring the lock. Defaults to False.
 
     Yields:
-        Iterator[UUID]: The session id of the lock.
+        Iterator[str]: The session id of the lock.
     """
-    session_id = uuid4()
+    session_id = str(uuid4())
     lock_acquired = False
     retry_attempt = 0
 
@@ -36,16 +41,19 @@ def lock(
             execute_statement(
                 conn=conn,
                 sql=f"""
-                    insert into {table} with l as (
+                    merge into {table} using (
                         select
                         '{client}' as client,
                         '{resource}' as resource,
                         '{session_id}' as session_id,
-                        true as acquired,
-                        current_timestamp() as acquired_ts
-                    )
-                    select * from l
-                    where not exists (select * from {table} where l.resource = {table}.resource and {table}.acquired = true and l.client != {table}.client)
+                        {session_lock} as session_locked
+                    ) as s on s.resource = lock.resource
+                    when not matched then insert (client, resource, acquired, session_id, session_locked) values (s.client, s.resource, true, s.session_id, s.session_locked)
+                    when matched and lock.acquired=false or (lock.client = s.client and s.session_locked = false) then update set
+                        lock.client=s.client,
+                        lock.acquired=true,
+                        lock.session_id=s.session_id,
+                        lock.session_locked=s.session_locked;
                 """,
             )
 
@@ -53,32 +61,25 @@ def lock(
                 conn=conn,
                 sql=f"""
                     select 
-                        client
-                    from {table} 
-                    where acquired=true
-                    qualify row_number() over (partition by resource order by acquired_ts, session_id) = 1
+                        client,
+                        session_id
+                    from {table}
+                    where resource='{resource}'
                 """,
             )
 
             if row:
                 in_use_client = row[0].get("CLIENT")
-
                 if in_use_client != client:
-                    logger.warning(
-                        "%s is in use by %s, could not acquire lock for %s",
-                        resource,
-                        in_use_client,
-                        client,
+                    raise ResourceLockedException(
+                        f"{resource} is in use by {in_use_client}, could not acquire lock for {client}"
                     )
-                    execute_statement(
-                        conn=conn,
-                        sql=f"""
-                        delete 
-                        from {table}
-                        where session_id='{session_id}'
-                        """,
+
+                if session_lock and row[0].get("SESSION_ID") != session_id:
+                    raise ResourceLockedException(
+                        f"{resource} is in use by another session of {client}, could not acquire lock"
                     )
-                    return
+
             lock_acquired = True
             yield session_id
         except ProgrammingError as e:
@@ -95,9 +96,9 @@ def lock(
                     create table {table} if not exists (
                         client varchar,
                         resource varchar,
-                        session_id varchar,
                         acquired boolean,
-                        acquired_ts timestamp_ltz,
+                        session_id varchar,
+                        session_locked boolean,
                         primary key(client,resource)
                     )
                     data_retention_time_in_days=0
@@ -107,14 +108,17 @@ def lock(
             logger.info("Created lock table %s and retrying", table)
         finally:
             if lock_acquired:
-                logger.info("Releasing locks on %s for %s", resource, client)
+                logger.info("Releasing lock for %s", resource)
                 execute_query(
                     conn=conn,
                     sql=f"""
                     update {table}
                     set acquired=false
-                    where client='{client}'
-                    and resource='{resource}'
+                    where resource='{resource}'
                     """,
                 )
                 retry_attempt = MAX_RETRIES
+
+
+class ResourceLockedException(Exception):
+    """Exception raised when a resource is locked."""


### PR DESCRIPTION
- Major rework of snowlock to allow for only a single lock per resource.
- Addition of optional `session_lock` parameter to allow for locking of a resource between sessions of the same client.